### PR TITLE
Reject bytes >= 0x80 when converting from ASCII

### DIFF
--- a/win_iconv.c
+++ b/win_iconv.c
@@ -1375,6 +1375,12 @@ kernel_mbtowc(csconv_t *cv, const uchar *buf, int bufsize, ushort *wbuf, int *wb
     len = cv->mblen(cv, buf, bufsize);
     if (len == -1)
         return -1;
+    /* If converting from ASCII, reject 8bit
+     * chars. MultiByteToWideChar() doesn't. Note that for ASCII we
+     * know that the mblen function is sbcs_mblen() so len is 1.
+     */
+    if (cv->codepage == 20127 && buf[0] >= 0x80)
+            return_error(EILSEQ);
     *wbufsize = MultiByteToWideChar(cv->codepage, mbtowc_flags (cv->codepage),
             (const char *)buf, len, (wchar_t *)wbuf, *wbufsize);
     if (*wbufsize == 0)


### PR DESCRIPTION
Patch taken from GLib (file still under the public domain).

This behavior is more consistent with other iconv implementations (like GNU libiconv, glibc and Mac OS X).