### PR TITLE
cmake: fix name of exe file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ endif(WIN_ICONV_BUILD_SHARED)
 
 if(WIN_ICONV_BUILD_EXECUTABLE)
     add_executable(win_iconv win_iconv.c iconv.h localcharset.h)
-    set_target_properties(win_iconv PROPERTIES COMPILE_FLAGS "-DMAKE_EXE")
+    set_target_properties(win_iconv PROPERTIES COMPILE_FLAGS "-DMAKE_EXE" OUTPUT_NAME "win_iconv.exe")
     install(TARGETS win_iconv RUNTIME DESTINATION bin
                               LIBRARY DESTINATION lib
                               ARCHIVE DESTINATION lib)


### PR DESCRIPTION
```
$ CC=x86_64-w64-mingw32-gcc cmake -B build3
-- The C compiler identification is GNU 14.0.0
-- The CXX compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - failed
-- Check for working C compiler: /usr/bin/x86_64-w64-mingw32-gcc
-- Check for working C compiler: /usr/bin/x86_64-w64-mingw32-gcc - works
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
-- Configuring done (0.6s)
-- Generating done (0.0s)
-- Build files have been written to: /home/user/wspace/win-iconv/build3

$ CC=x86_64-w64-mingw32-gcc cmake --build build3 --clean-first -j1
[ 16%] Building C object CMakeFiles/iconv_shared.dir/win_iconv.c.o
[ 33%] Linking C shared library iconv.so
[ 33%] Built target iconv_shared
[ 50%] Building C object CMakeFiles/win_iconv.dir/win_iconv.c.o
[ 66%] Linking C executable win_iconv
[ 66%] Built target win_iconv
[ 83%] Building C object CMakeFiles/iconv_static.dir/win_iconv.c.o
[100%] Linking C static library libiconv.a
[100%] Built target iconv_static

$ sudo cmake --install build3 --prefix="/tmp/usr/x86_64-w64-mingw32"
-- Install configuration: ""
-- Installing: /tmp/usr/x86_64-w64-mingw32/lib/iconv.so
CMake Error at build3/cmake_install.cmake:59 (file):
  file INSTALL cannot find "/home/user/wspace/win-iconv/build3/win_iconv": No
  such file or directory.
```